### PR TITLE
Audio audio-volume and audio-pitch css properties

### DIFF
--- a/Editor/Renderer/EditorContext.cs
+++ b/Editor/Renderer/EditorContext.cs
@@ -99,7 +99,7 @@ namespace ReactUnity.Editor.Renderer
             return res;
         }
 
-        public override void PlayAudio(AudioClip clip)
+        public override void PlayAudio(AudioClip clip, float volume, float pitch)
         {
             EditorSFX.PlayClip(clip);
         }

--- a/Runtime/Core/ReactContext.cs
+++ b/Runtime/Core/ReactContext.cs
@@ -168,7 +168,7 @@ namespace ReactUnity
             return src;
         }
 
-        public abstract void PlayAudio(AudioClip clip);
+        public abstract void PlayAudio(AudioClip clip, float volume, float pitch);
 
         public void Start(Action afterStart = null)
         {

--- a/Runtime/Frameworks/Noop/NoopContext.cs
+++ b/Runtime/Frameworks/Noop/NoopContext.cs
@@ -67,6 +67,6 @@ namespace ReactUnity.Noop
             return tc;
         }
 
-        public override void PlayAudio(AudioClip clip) { }
+        public override void PlayAudio(AudioClip clip, float volume, float pitch) { }
     }
 }

--- a/Runtime/Frameworks/UGUI/General/UGUIContext.cs
+++ b/Runtime/Frameworks/UGUI/General/UGUIContext.cs
@@ -158,7 +158,8 @@ namespace ReactUnity.UGUI
         public override void PlayAudio(AudioClip clip, float volume, float pitch)
         {
             var source = (Host as HostComponent).GetOrAddComponent<AudioSource>();
-            source.PlayOneShot(clip);
+            source.pitch = pitch;
+            source.PlayOneShot(clip, volume);
         }
 
         public GameObject CreateNativeObject(string name, params Type[] components)

--- a/Runtime/Frameworks/UGUI/General/UGUIContext.cs
+++ b/Runtime/Frameworks/UGUI/General/UGUIContext.cs
@@ -155,7 +155,7 @@ namespace ReactUnity.UGUI
             return tc;
         }
 
-        public override void PlayAudio(AudioClip clip)
+        public override void PlayAudio(AudioClip clip, float volume, float pitch)
         {
             var source = (Host as HostComponent).GetOrAddComponent<AudioSource>();
             source.PlayOneShot(clip);

--- a/Runtime/Frameworks/UIToolkit/General/ReactRendererUIToolkit.cs
+++ b/Runtime/Frameworks/UIToolkit/General/ReactRendererUIToolkit.cs
@@ -40,10 +40,11 @@ namespace ReactUnity.UIToolkit
             return ctx;
         }
 
-        public void PlayAudio(AudioClip clip)
+        public void PlayAudio(AudioClip clip, float volume, float pitch)
         {
             var source = GetComponent<AudioSource>();
-            source.PlayOneShot(clip);
+            source.pitch = pitch;
+            source.PlayOneShot(clip, volume);
         }
 
         protected override IMediaProvider CreateMediaProvider()

--- a/Runtime/Frameworks/UIToolkit/General/UIToolkitContext.cs
+++ b/Runtime/Frameworks/UIToolkit/General/UIToolkitContext.cs
@@ -115,7 +115,7 @@ namespace ReactUnity.UIToolkit
             return tc;
         }
 
-        public override void PlayAudio(AudioClip clip)
+        public override void PlayAudio(AudioClip clip, float volume, float pitch)
         {
             OnAudioPlayback?.Invoke(clip);
         }

--- a/Runtime/Frameworks/UIToolkit/General/UIToolkitContext.cs
+++ b/Runtime/Frameworks/UIToolkit/General/UIToolkitContext.cs
@@ -12,7 +12,7 @@ namespace ReactUnity.UIToolkit
         public new class Options : ReactContext.Options
         {
             public VisualElement HostElement;
-            public Action<AudioClip> OnAudioPlayback;
+            public Action<AudioClip, float, float> OnAudioPlayback;
             public override bool CalculatesLayout => false;
         }
 
@@ -69,7 +69,7 @@ namespace ReactUnity.UIToolkit
                 { "hover", typeof(HoverStateHandler) },
             };
 
-        private Action<AudioClip> OnAudioPlayback = null;
+        private Action<AudioClip, float, float> OnAudioPlayback = null;
 
         public VisualElement HostElement { get; }
 
@@ -117,7 +117,7 @@ namespace ReactUnity.UIToolkit
 
         public override void PlayAudio(AudioClip clip, float volume, float pitch)
         {
-            OnAudioPlayback?.Invoke(clip);
+            OnAudioPlayback?.Invoke(clip, volume, pitch);
         }
     }
 }

--- a/Runtime/Styling/NodeStyle.cs
+++ b/Runtime/Styling/NodeStyle.cs
@@ -122,6 +122,8 @@ namespace ReactUnity.Styling
         public ICssValueList<AudioReference> audioClip => GetStyleValue(StyleProperties.audioClip);
         public ICssValueList<int> audioIterationCount => GetStyleValue(StyleProperties.audioIterationCount);
         public ICssValueList<float> audioDelay => GetStyleValue(StyleProperties.audioDelay);
+        public ICssValueList<float> audioVolume => GetStyleValue(StyleProperties.audioVolume);
+        public ICssValueList<float> audioPitch => GetStyleValue(StyleProperties.audioPitch);
 
         #endregion
 

--- a/Runtime/Styling/Properties/StyleProperties.cs
+++ b/Runtime/Styling/Properties/StyleProperties.cs
@@ -113,7 +113,7 @@ namespace ReactUnity.Styling
         public static readonly ValueListStyleProperty<AudioReference> audioClip = new ValueListStyleProperty<AudioReference>("audioClip");
         public static readonly ValueListStyleProperty<int> audioIterationCount = new ValueListStyleProperty<int>("audioIterationCount", 1);
         public static readonly ValueListStyleProperty<float> audioDelay = new ValueListStyleProperty<float>("audioDelay");
-        public static readonly ValueListStyleProperty<float> audioVolume = new ValueListStyleProperty<float>("audioVolume", 1);
+        public static readonly ValueListStyleProperty<float> audioVolume = new ValueListStyleProperty<float>("audioVolume", 1f, true, baseConverter: AllConverters.PercentageConverter);
         public static readonly ValueListStyleProperty<float> audioPitch = new ValueListStyleProperty<float>("audioPitch", 1f);
 
         public static readonly Dictionary<string, IStyleProperty> PropertyMap = new Dictionary<string, IStyleProperty>(StringComparer.InvariantCultureIgnoreCase)

--- a/Runtime/Styling/Properties/StyleProperties.cs
+++ b/Runtime/Styling/Properties/StyleProperties.cs
@@ -113,6 +113,8 @@ namespace ReactUnity.Styling
         public static readonly ValueListStyleProperty<AudioReference> audioClip = new ValueListStyleProperty<AudioReference>("audioClip");
         public static readonly ValueListStyleProperty<int> audioIterationCount = new ValueListStyleProperty<int>("audioIterationCount", 1);
         public static readonly ValueListStyleProperty<float> audioDelay = new ValueListStyleProperty<float>("audioDelay");
+        public static readonly ValueListStyleProperty<float> audioVolume = new ValueListStyleProperty<float>("audioVolume", 1);
+        public static readonly ValueListStyleProperty<float> audioPitch = new ValueListStyleProperty<float>("audioPitch", 1f);
 
         public static readonly Dictionary<string, IStyleProperty> PropertyMap = new Dictionary<string, IStyleProperty>(StringComparer.InvariantCultureIgnoreCase)
         {
@@ -233,10 +235,14 @@ namespace ReactUnity.Styling
             { "audioClip", audioClip },
             { "audioDelay", audioDelay },
             { "audioIterationCount", audioIterationCount },
+            { "audioVolume", audioVolume },
+            { "audioPitch", audioPitch },
 
             { "audio-clip", audioClip },
             { "audio-delay", audioDelay },
             { "audio-iteration-count", audioIterationCount },
+            { "audio-volume", audioVolume },
+            { "audio-pitch", audioPitch },
 
             { "border-image-source", borderImageSource },
             { "border-image-slice", borderImageSlice },

--- a/Runtime/Styling/Shorthands/AudioShorthand.cs
+++ b/Runtime/Styling/Shorthands/AudioShorthand.cs
@@ -22,6 +22,8 @@ namespace ReactUnity.Styling.Shorthands
             var clips = new IComputedValue[count];
             var delays = new IComputedValue[count];
             var iterations = new IComputedValue[count];
+            var volumes = new IComputedValue[count];
+            var pitches = new IComputedValue[count];
 
             for (int ci = 0; ci < count; ci++)
             {
@@ -33,10 +35,34 @@ namespace ReactUnity.Styling.Shorthands
                 var countSet = false;
                 var delaySet = false;
                 var clipSet = false;
+                var volumeSet = false;
+                var pitchSet = false;
 
                 for (int i = 0; i < splits.Count; i++)
                 {
                     var split = splits[i];
+
+                    if (AllConverters.FloatConverter.TryParse(split, out var fpitch))
+                    {
+                        if (!pitchSet)
+                        {
+                            pitches[ci] = fpitch;
+                            pitchSet = true;
+                        }
+                        else return null;
+                        continue;
+                    }
+
+                    if (AllConverters.FloatConverter.TryParse(split, out var fvolume))
+                    {
+                        if (!volumeSet)
+                        {
+                            volumes[ci] = fvolume;
+                            volumeSet = true;
+                        }
+                        else return null;
+                        continue;
+                    }
 
                     if (AllConverters.IterationCountConverter.TryParse(split, out var fcount))
                     {
@@ -75,11 +101,15 @@ namespace ReactUnity.Styling.Shorthands
                 if (!clipSet) return null;
                 if (!delaySet) delays[ci] = new ComputedConstant(0f);
                 if (!countSet) iterations[ci] = new ComputedConstant(1);
+                if (!volumeSet) volumes[ci] = new ComputedConstant(1f);
+                if (!pitchSet) pitches[ci] = new ComputedConstant(1f);
             }
 
             collection[StyleProperties.audioClip] = StyleProperties.audioClip.Converter.FromList(clips);
             collection[StyleProperties.audioDelay] = StyleProperties.audioDelay.Converter.FromList(delays);
             collection[StyleProperties.audioIterationCount] = StyleProperties.audioIterationCount.Converter.FromList(iterations);
+            collection[StyleProperties.audioVolume] = StyleProperties.audioVolume.Converter.FromList(volumes);
+            collection[StyleProperties.audioPitch] = StyleProperties.audioPitch.Converter.FromList(pitches);
 
             return ModifiedProperties;
         }

--- a/Runtime/Styling/Shorthands/AudioShorthand.cs
+++ b/Runtime/Styling/Shorthands/AudioShorthand.cs
@@ -23,7 +23,6 @@ namespace ReactUnity.Styling.Shorthands
             var delays = new IComputedValue[count];
             var iterations = new IComputedValue[count];
             var volumes = new IComputedValue[count];
-            var pitches = new IComputedValue[count];
 
             for (int ci = 0; ci < count; ci++)
             {
@@ -36,33 +35,10 @@ namespace ReactUnity.Styling.Shorthands
                 var delaySet = false;
                 var clipSet = false;
                 var volumeSet = false;
-                var pitchSet = false;
 
                 for (int i = 0; i < splits.Count; i++)
                 {
                     var split = splits[i];
-
-                    if (AllConverters.FloatConverter.TryParse(split, out var fpitch))
-                    {
-                        if (!pitchSet)
-                        {
-                            pitches[ci] = fpitch;
-                            pitchSet = true;
-                        }
-                        else return null;
-                        continue;
-                    }
-
-                    if (AllConverters.FloatConverter.TryParse(split, out var fvolume))
-                    {
-                        if (!volumeSet)
-                        {
-                            volumes[ci] = fvolume;
-                            volumeSet = true;
-                        }
-                        else return null;
-                        continue;
-                    }
 
                     if (AllConverters.IterationCountConverter.TryParse(split, out var fcount))
                     {
@@ -70,6 +46,17 @@ namespace ReactUnity.Styling.Shorthands
                         {
                             iterations[ci] = fcount;
                             countSet = true;
+                        }
+                        else return null;
+                        continue;
+                    }
+
+                    if (AllConverters.PercentageConverter.TryParse(split, out var fvolume))
+                    {
+                        if (!volumeSet)
+                        {
+                            volumes[ci] = fvolume;
+                            volumeSet = true;
                         }
                         else return null;
                         continue;
@@ -102,14 +89,12 @@ namespace ReactUnity.Styling.Shorthands
                 if (!delaySet) delays[ci] = new ComputedConstant(0f);
                 if (!countSet) iterations[ci] = new ComputedConstant(1);
                 if (!volumeSet) volumes[ci] = new ComputedConstant(1f);
-                if (!pitchSet) pitches[ci] = new ComputedConstant(1f);
             }
 
             collection[StyleProperties.audioClip] = StyleProperties.audioClip.Converter.FromList(clips);
             collection[StyleProperties.audioDelay] = StyleProperties.audioDelay.Converter.FromList(delays);
             collection[StyleProperties.audioIterationCount] = StyleProperties.audioIterationCount.Converter.FromList(iterations);
             collection[StyleProperties.audioVolume] = StyleProperties.audioVolume.Converter.FromList(volumes);
-            collection[StyleProperties.audioPitch] = StyleProperties.audioPitch.Converter.FromList(pitches);
 
             return ModifiedProperties;
         }

--- a/Runtime/Styling/StyleState.cs
+++ b/Runtime/Styling/StyleState.cs
@@ -688,7 +688,7 @@ namespace ReactUnity.Styling
                     clip.Get(i, AudioReference.None).Get(Context, (cl) => {
                         state.Clip = cl;
                         state.Volume = volume.Get(i, 1);
-                        state.Pitch = volume.Get(i, 1);
+                        state.Pitch = pitch.Get(i, 1);
                         state.Loaded = true;
                         state.Loading = false;
 

--- a/Runtime/Styling/StyleState.cs
+++ b/Runtime/Styling/StyleState.cs
@@ -64,8 +64,6 @@ namespace ReactUnity.Styling
             public bool Loaded;
             public bool Loading;
             public UnityEngine.AudioClip Clip;
-            public float Volume;
-            public float Pitch;
             public bool ShouldStart;
             public int CurrentLoop = 0;
         }
@@ -668,12 +666,14 @@ namespace ReactUnity.Styling
 
                 var state = audioStates[i] = audioStates[i] ?? new AudioState();
 
+                var curVolume = volume.Get(i, 1);
+                var curPitch = pitch.Get(i, 1);
 
                 Action tryPlayClip = () => {
                     if (state.Loaded && state.ShouldStart)
                     {
                         state.ShouldStart = false;
-                        Context.PlayAudio(state.Clip, state.Volume, state.Pitch);
+                        Context.PlayAudio(state.Clip, curVolume, curPitch);
                     }
                 };
 
@@ -687,8 +687,6 @@ namespace ReactUnity.Styling
 
                     clip.Get(i, AudioReference.None).Get(Context, (cl) => {
                         state.Clip = cl;
-                        state.Volume = volume.Get(i, 1);
-                        state.Pitch = pitch.Get(i, 1);
                         state.Loaded = true;
                         state.Loading = false;
 

--- a/Runtime/Styling/StyleState.cs
+++ b/Runtime/Styling/StyleState.cs
@@ -654,8 +654,8 @@ namespace ReactUnity.Styling
             var clip = Current.audioClip;
             var delay = Current.audioDelay;
             var iterationCount = Current.audioIterationCount;
-            var volume = Current.volume;
-            var pitch = Current.pitch;
+            var volume = Current.audioVolume;
+            var pitch = Current.audioPitch;
 
             var maxLength = Mathf.Max(delay.Count, iterationCount.Count, clip.Count, volume.Count, pitch.Count);
 

--- a/Runtime/Styling/StyleState.cs
+++ b/Runtime/Styling/StyleState.cs
@@ -64,6 +64,8 @@ namespace ReactUnity.Styling
             public bool Loaded;
             public bool Loading;
             public UnityEngine.AudioClip Clip;
+            public float Volume;
+            public float Pitch;
             public bool ShouldStart;
             public int CurrentLoop = 0;
         }
@@ -652,8 +654,10 @@ namespace ReactUnity.Styling
             var clip = Current.audioClip;
             var delay = Current.audioDelay;
             var iterationCount = Current.audioIterationCount;
+            var volume = Current.volume;
+            var pitch = Current.pitch;
 
-            var maxLength = Mathf.Max(delay.Count, iterationCount.Count, clip.Count);
+            var maxLength = Mathf.Max(delay.Count, iterationCount.Count, clip.Count, volume.Count, pitch.Count);
 
             if (audioStates == null) audioStates = new AudioState[maxLength];
 
@@ -669,7 +673,7 @@ namespace ReactUnity.Styling
                     if (state.Loaded && state.ShouldStart)
                     {
                         state.ShouldStart = false;
-                        Context.PlayAudio(state.Clip);
+                        Context.PlayAudio(state.Clip, state.Volume, state.Pitch);
                     }
                 };
 
@@ -683,6 +687,8 @@ namespace ReactUnity.Styling
 
                     clip.Get(i, AudioReference.None).Get(Context, (cl) => {
                         state.Clip = cl;
+                        state.Volume = volume.Get(i, 1);
+                        state.Pitch = volume.Get(i, 1);
                         state.Loaded = true;
                         state.Loading = false;
 

--- a/Tests/Runtime/Animations/AudioTests.cs
+++ b/Tests/Runtime/Animations/AudioTests.cs
@@ -14,7 +14,7 @@ namespace ReactUnity.Tests
         {
             var view = Q("#test");
 
-            view.Style.Set("audio", $"url({TestHelpers.ClickUrl}) 3s 5, url(https://example.com/file.ogg) infinite 2s, url(res:something)");
+            view.Style.Set("audio", $"url({TestHelpers.ClickUrl}) 3s 5, url(https://example.com/file.ogg) infinite 2s, url(res:something), url(res:something) 50%");
             yield return null;
 
             var st = view.ComputedStyle;
@@ -35,6 +35,13 @@ namespace ReactUnity.Tests
             Assert.AreEqual(1, st.audioIterationCount.Get(2));
 
 
+            Assert.AreEqual(AssetReferenceType.Resource, st.audioClip.Get(3).Type);
+            Assert.AreEqual("something", st.audioClip.Get(3).Value);
+            Assert.AreEqual(0, st.audioDelay.Get(3));
+            Assert.AreEqual(1, st.audioIterationCount.Get(3));
+            Assert.AreEqual(0.5f, st.audioVolume.Get(3));
+
+
             view.Style.Set("audio", "none");
             yield return null;
 
@@ -42,6 +49,7 @@ namespace ReactUnity.Tests
             Assert.AreEqual(null, st.audioClip.Get(0));
             Assert.AreEqual(0, st.audioDelay.Get(0));
             Assert.AreEqual(1, st.audioIterationCount.Get(0, 1));
+            Assert.AreEqual(1, st.audioVolume.Get(0, 1));
 
         }
     }


### PR DESCRIPTION
I've added `audio-volume` and `audio-pitch` css properties.

Example:
```css
.button {
  &:focus {
    audio: url(res:UI/selected);
    audio-volume: 50%;
    audio-pitch: 2;
  }
}
```

Or also in the compound form:
```css
audio: url(res:UI/selected) 200ms 1 50%;
// or
audio: url(res:UI/selected) 30%;
```

Caveats:

- It doesn't work in with Editor UIToolkit (no support for pitch and volume)