### PR TITLE
Fix gradient sprite color mismatch by using Linear texture and color conversion

### DIFF
--- a/Runtime/Types/Gradient.cs
+++ b/Runtime/Types/Gradient.cs
@@ -183,7 +183,8 @@ namespace ReactUnity.Types
                 var t = i * resRp;
                 var rt = length * t + offset;
 
-                var px = GetColorForOffset(distance, rt);
+                // Convert to linear space as the texture is marked as linear
+                var px = GetColorForOffset(distance, rt).linear;
 
                 // This is done so that transparent pixels have same color channel as next pixel
                 // So that the bilinear interpolation shows a better texture


### PR DESCRIPTION
The generated gradient texture was treating sRGB color values as Linear, causing a brightness/hue shift in the editor. This change ensures the texture is created with the linear flag set to true, and sRGB gradient colors are correctly converted to Linear space using .linear before being written to the texture. This results in the displayed colors matching the defined gradient keys.